### PR TITLE
use `Segment.is_empty seg` instead of `seg = emtpy`

### DIFF
--- a/src/cursor.ml
+++ b/src/cursor.ml
@@ -452,7 +452,7 @@ let access_gen cur seg =
           | Extender (extender, node_below, indexed, hashed) ->
               let (shared, remaining_extender, remaining_segment) =
                 Segment.common_prefix extender segment in
-              if remaining_extender = Segment.empty then
+              if Segment.is_empty remaining_extender then
                 let new_trail =
                   _Extended (trail, extender, Unmodified (indexed, hashed)) in
                 aux (_Cursor (new_trail, node_below, context)) remaining_segment

--- a/src/node.ml
+++ b/src/node.ml
@@ -199,7 +199,7 @@ let _Extender (p, n, ir, hit) =
 let new_leaf v = View (_Leaf (v, Not_Indexed, Not_Hashed))
 
 let new_extend : Segment.segment -> node -> node = fun segment node ->
-  if segment = Segment.empty then node
+  if Segment.is_empty segment then node
   else 
     match node with
     | View (Extender (seg, n, _, _)) ->


### PR DESCRIPTION
There are  checking condition whether the segment is empty using `(=)`. This PR fixes the conditions to use `Segment.is_empty`.